### PR TITLE
fix multiple definitions of user_friendly_id

### DIFF
--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -33,7 +33,7 @@
 
 #include <gtk/gtk.h>
 #include <lo/lo.h>
- 
+
 #include "nekobee_types.h"
 #include "nekobee.h"
 #include "gui_callbacks.h"
@@ -42,6 +42,7 @@
 
 /* ==== global variables ==== */
 
+char *     user_friendly_id;
 char *     osc_host_url;
 char *     osc_self_url;
 lo_address osc_host_address;

--- a/src/gui_main.h
+++ b/src/gui_main.h
@@ -28,7 +28,7 @@
 #include <lo/lo.h>
 
 #include "nekobee_types.h"
-char *user_friendly_id;
+extern char *     user_friendly_id;
 extern char *     osc_host_url;
 extern char *     osc_self_url;
 extern lo_address osc_host_address;


### PR DESCRIPTION
multiple definitions of user_friendly_id was causing the linker to fail.
I followed the example of all the osc global variables and moved the definition to gui_main.c